### PR TITLE
feat(cli): add `--no-push` option to `pr create` and other enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ sayless pr create
 # Create PR targeting specific base branch
 sayless pr create --base develop
 
+# Create PR with AI insights
+sayless pr create --details
+
+# Create PR without auto-pushing branch
+sayless pr create --no-push
+
 # List open PRs
 sayless pr list
 

--- a/sayless.egg-info/PKG-INFO
+++ b/sayless.egg-info/PKG-INFO
@@ -172,6 +172,12 @@ sayless pr create
 # Create PR targeting specific base branch
 sayless pr create --base develop
 
+# Create PR with AI insights
+sayless pr create --details
+
+# Create PR without auto-pushing branch
+sayless pr create --no-push
+
 # List open PRs
 sayless pr list
 

--- a/sayless/cli/core.py
+++ b/sayless/cli/core.py
@@ -1067,13 +1067,14 @@ def pr_command(
     action: str = typer.Argument(..., help="Action to perform: create, list"),
     base: str = typer.Option(None, "--base", "-b", help="Base branch for PR (default: main)"),
     details: bool = typer.Option(False, "--details", "-d", help="Show AI-generated insights"),
+    no_push: bool = typer.Option(False, "--no-push", help="Don't automatically push branch to GitHub"),
 ):
     """Manage pull requests with AI assistance"""
     show_welcome_message()
     ensure_openai_configured()
     
     if action == "create":
-        create_pr(base=base, show_details=details)
+        create_pr(base=base, show_details=details, auto_push=not no_push)
     elif action == "list":
         list_prs(show_details=details)
     else:


### PR DESCRIPTION
- Introduced `--no-push` option to `pr create` for manual branch push
- Added auto-stage option to branch command and improved label inference
- Enabled AI-generated branch name from staged changes
- Enhanced error handling and validation for PR creation
- Improved AI response parsing and PR creation UI
- Improved error handling for empty branch commits in PR creation